### PR TITLE
fix: correct Dockerfile COPY paths for custom Prisma client output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,12 @@ COPY --from=builder /usr/src/app/dist ./dist
 # Copy prisma schema and migrations for migrate deploy
 COPY --from=builder /usr/src/app/prisma ./prisma
 
-# Copy generated prisma client and CLI from builder
-COPY --from=builder /usr/src/app/node_modules/.prisma ./node_modules/.prisma
+# Copy generated prisma client from builder (output path matches schema.prisma: ../src/generated/prisma)
+COPY --from=builder /usr/src/app/src/generated ./src/generated
+
+# Copy prisma CLI from builder for migrate deploy
 COPY --from=builder /usr/src/app/node_modules/prisma ./node_modules/prisma
+COPY --from=builder /usr/src/app/node_modules/@prisma ./node_modules/@prisma
 
 # Set user
 USER nodejs


### PR DESCRIPTION
## Summary

- Fix Docker build failure caused by incorrect COPY path for generated Prisma client
- Prisma schema uses custom output `../src/generated/prisma` instead of default `node_modules/.prisma`
- Add `@prisma` package copy for runtime Prisma client support in production stage

## Root Cause

The `schema.prisma` sets `output = "../src/generated/prisma"`, so `prisma generate` places the client in `src/generated/prisma`. The Dockerfile was attempting to copy from `node_modules/.prisma` which never gets created, causing the build to fail with `not found`.

## Test plan

- [ ] Docker build completes without error on CI
- [ ] `prisma migrate deploy` runs successfully in the production container
- [ ] Bot starts and connects to the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dockerfile-only change; low risk aside from potentially increasing image size or missing other runtime Prisma files if the dependency layout differs.
> 
> **Overview**
> Fixes the production Docker image build/runtime by updating the Prisma client COPY step to match the custom generator output (`../src/generated/prisma`) instead of `node_modules/.prisma`.
> 
> Also copies `node_modules/@prisma` (alongside `node_modules/prisma`) into the runtime image so `npx prisma migrate deploy` and the generated client have the required Prisma runtime dependencies in production.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 341e593a70d931569496c7befc952b2e921ff422. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->