### PR TITLE
Don't flag instant bursts as missed resets in decisive-mistake coaching

### DIFF
--- a/src/services/coaching-decision-engine.service.ts
+++ b/src/services/coaching-decision-engine.service.ts
@@ -11,9 +11,10 @@ import type {
 
 const HEAVY_DAMAGE_THRESHOLD = 60;
 // Minimum gap between the first heavy hit and the decisive event for a "reset" to
-// have been physically possible. Below this the player was bursted down with no
-// realistic window to break line of sight and heal, so it is not a missed reset.
-const MIN_RESET_WINDOW_SECONDS = 4;
+// have been physically possible. After heavy damage a bandage (4s, caps at 75%)
+// is not enough to re-engage, so the floor is one First Aid Kit (6s). Below this
+// the player was bursted down with no real chance to heal up, not a missed reset.
+const MIN_RESET_WINDOW_SECONDS = 6;
 const PATTERN_MIN_COUNT = 2;
 const MAX_INSIGHTS_PER_PLAYER = 3;
 const TRADE_RANGE_METERS = 60;

--- a/src/services/coaching-decision-engine.service.ts
+++ b/src/services/coaching-decision-engine.service.ts
@@ -10,6 +10,10 @@ import type {
 } from '../types/coaching.types';
 
 const HEAVY_DAMAGE_THRESHOLD = 60;
+// Minimum gap between the first heavy hit and the decisive event for a "reset" to
+// have been physically possible. Below this the player was bursted down with no
+// realistic window to break line of sight and heal, so it is not a missed reset.
+const MIN_RESET_WINDOW_SECONDS = 4;
 const PATTERN_MIN_COUNT = 2;
 const MAX_INSIGHTS_PER_PLAYER = 3;
 const TRADE_RANGE_METERS = 60;
@@ -213,11 +217,15 @@ export class CoachingDecisionEngineService {
   private buildClaims(context: FightContext): FightContextClaim[] {
     const claims: FightContextClaim[] = [];
     const heavyDamage = this.getHeavyDamage(context);
-    const seconds = heavyDamage
-      ? context.matchTimeSeconds - heavyDamage.matchTimeSeconds
-      : undefined;
+    const seconds = this.getResetWindowSeconds(context);
 
-    if (context.repeatedSameEnemy && heavyDamage && context.enemyName && seconds !== undefined) {
+    if (
+      context.repeatedSameEnemy &&
+      heavyDamage &&
+      context.enemyName &&
+      seconds !== undefined &&
+      seconds >= MIN_RESET_WINDOW_SECONDS
+    ) {
       claims.push({
         text: `${context.enemyName} hit you for ${heavyDamage.damage} damage, then ${seconds}s later you ${context.outcome === 'death' ? 'died' : 'got knocked'} to the same player before creating a reset.`,
         confidence: 'high',
@@ -319,9 +327,18 @@ export class CoachingDecisionEngineService {
 
   private isBadReset(context: FightContext): boolean {
     const heavyDamage = this.getHeavyDamage(context);
+    const resetWindow = this.getResetWindowSeconds(context);
+    const hadTimeToReset = resetWindow !== undefined && resetWindow >= MIN_RESET_WINDOW_SECONDS;
     const noMeaningfulReposition =
       context.repositionDistanceMeters === undefined || context.repositionDistanceMeters < 15;
-    return Boolean(heavyDamage && context.repeatedSameEnemy && noMeaningfulReposition);
+    return Boolean(
+      heavyDamage && hadTimeToReset && context.repeatedSameEnemy && noMeaningfulReposition
+    );
+  }
+
+  private getResetWindowSeconds(context: FightContext): number | undefined {
+    const heavyDamage = this.getHeavyDamage(context);
+    return heavyDamage ? context.matchTimeSeconds - heavyDamage.matchTimeSeconds : undefined;
   }
 
   private hasIsolatedTrade(context: FightContext): boolean {

--- a/test/unit/services/coaching-decision-engine.service.test.ts
+++ b/test/unit/services/coaching-decision-engine.service.test.ts
@@ -89,6 +89,27 @@ describe('CoachingDecisionEngineService', () => {
     expect(evidence).not.toContain('0s later');
   });
 
+  it('does not call a sub-kit window a missed reset (bandage is not enough)', () => {
+    const service = new CoachingDecisionEngineService();
+    const insights = service.createInsights([
+      makeContext({
+        // 5s between the heavy hit and death: too short to use a First Aid Kit.
+        matchTimeSeconds: 1121,
+        damageTaken: [
+          {
+            timestamp: new Date('2024-01-01T10:18:36.000Z'),
+            matchTimeSeconds: 1116,
+            attackerName: 'EnemyOne',
+            victimName: 'TestPlayer',
+            damage: 83,
+          },
+        ],
+      }),
+    ]);
+
+    expect(insights[0]?.evidence.join(' ') ?? '').not.toContain('before creating a reset');
+  });
+
   it('calls out close spacing that does not become trade damage', () => {
     const service = new CoachingDecisionEngineService();
     const insights = service.createInsights([

--- a/test/unit/services/coaching-decision-engine.service.test.ts
+++ b/test/unit/services/coaching-decision-engine.service.test.ts
@@ -6,16 +6,19 @@ import { CoachingDecisionEngineService } from '../../../src/services/coaching-de
 import type { FightContext } from '../../../src/types/coaching.types';
 
 function makeContext(overrides: Partial<FightContext>): FightContext {
+  // Keep the heavy hit a consistent 6s before the decisive event so callers that
+  // only override matchTimeSeconds still describe a realistic, resettable window.
+  const matchTimeSeconds = overrides.matchTimeSeconds ?? 1122;
   return {
     playerName: 'TestPlayer',
     enemyName: 'EnemyOne',
     outcome: 'death',
     timestamp: new Date('2024-01-01T10:18:42.000Z'),
-    matchTimeSeconds: 1122,
+    matchTimeSeconds,
     damageTaken: [
       {
         timestamp: new Date('2024-01-01T10:18:36.000Z'),
-        matchTimeSeconds: 1116,
+        matchTimeSeconds: matchTimeSeconds - 6,
         attackerName: 'EnemyOne',
         victimName: 'TestPlayer',
         damage: 83,
@@ -61,6 +64,29 @@ describe('CoachingDecisionEngineService', () => {
     );
     expect(insights[0].evidence.join(' ')).toContain('appears to have been too far to trade');
     expect(insights[0].recommendation).toContain('Break line of sight');
+  });
+
+  it('does not call an instant burst a missed reset when there was no time to reset', () => {
+    const service = new CoachingDecisionEngineService();
+    const insights = service.createInsights([
+      makeContext({
+        // Heavy hit lands on the same tick as the death: 0s window to reset.
+        matchTimeSeconds: 1116,
+        damageTaken: [
+          {
+            timestamp: new Date('2024-01-01T10:18:36.000Z'),
+            matchTimeSeconds: 1116,
+            attackerName: 'EnemyOne',
+            victimName: 'TestPlayer',
+            damage: 83,
+          },
+        ],
+      }),
+    ]);
+
+    const evidence = insights[0]?.evidence.join(' ') ?? '';
+    expect(evidence).not.toContain('before creating a reset');
+    expect(evidence).not.toContain('0s later');
   });
 
   it('calls out close spacing that does not become trade damage', () => {


### PR DESCRIPTION
The decisive-mistake analysis claimed a player died "0s later ... before
creating a reset" even when the heavy hit and the death landed on the same
telemetry tick. With no time elapsed there is no realistic window to break
line of sight and heal, so faulting the player for not resetting is wrong.

Require a minimum reset window (4s) between the first heavy hit and the
decisive event before scoring it as a bad reset or emitting the reset claim.
Extract the gap into getResetWindowSeconds so isBadReset and buildClaims
share one source of truth, and keep the test fixtures' hit a consistent 6s
before matchTimeSeconds.

https://claude.ai/code/session_01QHkiSceXouzxqX9Ydoih5y