### PR TITLE
feat: add opponent difficulty scoring

### DIFF
--- a/src/services/discord-bot.service.ts
+++ b/src/services/discord-bot.service.ts
@@ -51,6 +51,10 @@ import { DamageInfoUtils } from '../utils/damage-info.util';
 import { debug, error, success } from '../utils/logger';
 // No longer need custom mappings - using pubg-ts dictionaries
 import { MatchColorUtil } from '../utils/match-colors.util';
+import {
+  calculateOpponentDifficulty,
+  type OpponentDifficultyResult,
+} from '../utils/match-difficulty.util';
 import { CoachingDecisionEngineService } from './coaching-decision-engine.service';
 import { CoachingNarratorService } from './coaching-narrator.service';
 import { CoachingPipelineService } from './coaching-pipeline.service';
@@ -815,23 +819,23 @@ export class DiscordBotService {
     const totalKills = players.reduce((acc, player) => acc + (player.stats?.kills || 0), 0);
     const totalDBNOs = players.reduce((acc, player) => acc + (player.stats?.DBNOs || 0), 0);
 
+    const mainDescriptionLines = [
+      `⏰ **${dateString}**`,
+      `🗺️ **${this.formatMapName(mapName)}** • ${this.formatGameMode(gameMode)}`,
+      '',
+      '**Team Performance**',
+      `🏆 Placement: **${teamRankText}**`,
+      `👥 Squad Size: **${players.length} players**`,
+      '',
+      '**Combat Summary**',
+      `⚔️ Total Kills: **${totalKills}**`,
+      `🔻 Total Knocks: **${totalDBNOs}**`,
+      `💥 Total Damage: **${Math.round(totalDamage)}**`,
+    ];
+
     const mainEmbed = new EmbedBuilder()
       .setTitle('🎮 PUBG Match Summary')
-      .setDescription(
-        [
-          `⏰ **${dateString}**`,
-          `🗺️ **${this.formatMapName(mapName)}** • ${this.formatGameMode(gameMode)}`,
-          '',
-          '**Team Performance**',
-          `🏆 Placement: **${teamRankText}**`,
-          `👥 Squad Size: **${players.length} players**`,
-          '',
-          '**Combat Summary**',
-          `⚔️ Total Kills: **${totalKills}**`,
-          `🔻 Total Knocks: **${totalDBNOs}**`,
-          `💥 Total Damage: **${Math.round(totalDamage)}**`,
-        ].join('\n')
-      )
+      .setDescription(mainDescriptionLines.join('\n'))
       .setColor(matchColor)
       .setFooter({ text: `PUBG Match Tracker - ${matchId}` })
       .setTimestamp(matchDate);
@@ -869,36 +873,13 @@ export class DiscordBotService {
             }
           }
 
-          // Collect unique accountIds from kill/death events for season stats
-          const relevantAccountIds = new Set<string>();
-          for (const player of players) {
-            const analysis = matchAnalysis.playerAnalyses.get(player.name);
-            if (!analysis) continue;
-            for (const k of analysis.killEvents) {
-              if (k.victim?.accountId) relevantAccountIds.add(k.victim.accountId);
-            }
-            for (const k of analysis.deathEvents) {
-              if (k.killer?.accountId) relevantAccountIds.add(k.killer.accountId);
-            }
-            for (const k of analysis.knockdownEvents) {
-              if (k.victim?.accountId) relevantAccountIds.add(k.victim.accountId);
-            }
-            for (const k of analysis.knockedDownEvents) {
-              if (k.attacker?.accountId) relevantAccountIds.add(k.attacker.accountId);
-            }
-          }
-
-          let seasonStats: Map<string, { kd: number; adr: number }> | undefined;
-          if (relevantAccountIds.size > 0) {
-            try {
-              seasonStats = await this.playerStatsService.getSeasonStats(
-                Array.from(relevantAccountIds),
-                summary.gameMode
-              );
-            } catch (err) {
-              debug(`Failed to fetch season stats: ${err}`);
-            }
-          }
+          const seasonStats = await this.applyOpponentDifficulty(
+            mainEmbed,
+            mainDescriptionLines,
+            matchAnalysis,
+            players,
+            summary.gameMode
+          );
 
           const enhancedPlayerEmbeds = players.map((player) => {
             const analysis = matchAnalysis.playerAnalyses.get(player.name);
@@ -954,36 +935,13 @@ export class DiscordBotService {
         }
       }
 
-      // Collect unique accountIds from kill/death events for season stats
-      const relevantAccountIds = new Set<string>();
-      for (const player of players) {
-        const analysis = matchAnalysis.playerAnalyses.get(player.name);
-        if (!analysis) continue;
-        for (const k of analysis.killEvents) {
-          if (k.victim?.accountId) relevantAccountIds.add(k.victim.accountId);
-        }
-        for (const k of analysis.deathEvents) {
-          if (k.killer?.accountId) relevantAccountIds.add(k.killer.accountId);
-        }
-        for (const k of analysis.knockdownEvents) {
-          if (k.victim?.accountId) relevantAccountIds.add(k.victim.accountId);
-        }
-        for (const k of analysis.knockedDownEvents) {
-          if (k.attacker?.accountId) relevantAccountIds.add(k.attacker.accountId);
-        }
-      }
-
-      let seasonStats: Map<string, { kd: number; adr: number }> | undefined;
-      if (relevantAccountIds.size > 0) {
-        try {
-          seasonStats = await this.playerStatsService.getSeasonStats(
-            Array.from(relevantAccountIds),
-            summary.gameMode
-          );
-        } catch (err) {
-          debug(`Failed to fetch season stats: ${err}`);
-        }
-      }
+      const seasonStats = await this.applyOpponentDifficulty(
+        mainEmbed,
+        mainDescriptionLines,
+        matchAnalysis,
+        players,
+        summary.gameMode
+      );
 
       // Create enhanced embeds
       const enhancedPlayerEmbeds = players.map((player) => {
@@ -1230,6 +1188,80 @@ export class DiscordBotService {
       .setTitle(this.formatPlayerTitle(player))
       .setDescription(basicStats)
       .setColor(matchColor);
+  }
+
+  /**
+   * Collects encountered opponents, fetches their season stats, and appends
+   * the opponent-difficulty line to the main embed when usable. Returns the
+   * season-stats map (or undefined) for downstream per-player enrichment.
+   */
+  private async applyOpponentDifficulty(
+    mainEmbed: EmbedBuilder,
+    mainDescriptionLines: string[],
+    matchAnalysis: MatchAnalysis,
+    players: DiscordPlayerMatchStats[],
+    gameMode: string
+  ): Promise<Map<string, { kd: number; adr: number }> | undefined> {
+    const opponentAccountIds = this.collectOpponentAccountIds(matchAnalysis, players);
+    if (opponentAccountIds.length === 0) return undefined;
+
+    let seasonStats: Map<string, { kd: number; adr: number }> | undefined;
+    try {
+      seasonStats = await this.playerStatsService.getSeasonStats(opponentAccountIds, gameMode);
+    } catch (err) {
+      debug(`Failed to fetch season stats: ${err}`);
+    }
+
+    if (seasonStats) {
+      const difficulty = calculateOpponentDifficulty(opponentAccountIds, seasonStats);
+      if (difficulty) {
+        mainDescriptionLines.push(this.formatOpponentDifficulty(difficulty));
+        mainEmbed.setDescription(mainDescriptionLines.join('\n'));
+      }
+    }
+
+    return seasonStats;
+  }
+
+  /**
+   * Collects unique opponent accountIds encountered by the tracked squad.
+   *
+   * Walks the per-player telemetry analyses (kills, deaths, knockdowns,
+   * knocked-down events) and gathers the opposing players' accountIds while
+   * excluding any accountId that belongs to a tracked squad member.
+   */
+  private collectOpponentAccountIds(
+    matchAnalysis: MatchAnalysis,
+    players: DiscordPlayerMatchStats[]
+  ): string[] {
+    const trackedAccountIds = new Set(
+      players.map((player) => player.pubgId).filter((id): id is string => Boolean(id))
+    );
+    const opponentAccountIds = new Set<string>();
+
+    const addOpponent = (accountId?: string) => {
+      if (!accountId || trackedAccountIds.has(accountId)) return;
+      opponentAccountIds.add(accountId);
+    };
+
+    for (const player of players) {
+      const analysis = matchAnalysis.playerAnalyses.get(player.name);
+      if (!analysis) continue;
+      for (const event of analysis.killEvents) addOpponent(event.victim?.accountId);
+      for (const event of analysis.deathEvents) addOpponent(event.killer?.accountId);
+      for (const event of analysis.knockdownEvents) addOpponent(event.victim?.accountId);
+      for (const event of analysis.knockedDownEvents) addOpponent(event.attacker?.accountId);
+    }
+
+    return Array.from(opponentAccountIds);
+  }
+
+  /**
+   * Formats an opponent difficulty result into a main-summary description line.
+   */
+  private formatOpponentDifficulty(difficulty: OpponentDifficultyResult): string {
+    const opponentWord = difficulty.opponentCount === 1 ? 'opponent' : 'opponents';
+    return `Opponent Difficulty: **${difficulty.label}** (${difficulty.score}/100, ${difficulty.opponentCount} ${opponentWord})`;
   }
 
   /**

--- a/src/utils/match-difficulty.util.ts
+++ b/src/utils/match-difficulty.util.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure opponent difficulty calculator.
+ *
+ * Converts encountered opponents' season K/D and ADR into a match-level
+ * 0-100 score and label. Has no Discord, repository, PUBG API, or
+ * environment dependencies.
+ */
+
+export interface OpponentSeasonStats {
+  kd: number;
+  adr: number;
+}
+
+export type OpponentDifficultyLabel = 'Easy' | 'Standard' | 'Hard' | 'Brutal';
+
+export interface OpponentDifficultyResult {
+  score: number;
+  label: OpponentDifficultyLabel;
+  opponentCount: number;
+}
+
+const BASE_KD = 1.0;
+const BASE_ADR = 150;
+const SCORE_SCALE = 50;
+const MIN_SCORE = 0;
+const MAX_SCORE = 100;
+
+function isUsableStat(value: number): boolean {
+  return Number.isFinite(value) && value >= 0;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function scoreOpponent(stats: OpponentSeasonStats): number {
+  const raw = ((stats.kd / BASE_KD) + (stats.adr / BASE_ADR)) / 2 * SCORE_SCALE;
+  return clamp(Math.round(raw), MIN_SCORE, MAX_SCORE);
+}
+
+function labelFor(score: number): OpponentDifficultyLabel {
+  if (score <= 34) return 'Easy';
+  if (score <= 64) return 'Standard';
+  if (score <= 84) return 'Hard';
+  return 'Brutal';
+}
+
+export function calculateOpponentDifficulty(
+  opponentAccountIds: Iterable<string>,
+  seasonStats: Map<string, OpponentSeasonStats>
+): OpponentDifficultyResult | null {
+  const uniqueIds = new Set(opponentAccountIds);
+  const scores: number[] = [];
+
+  for (const id of uniqueIds) {
+    if (!id) continue;
+    const stats = seasonStats.get(id);
+    if (!stats) continue;
+    if (!isUsableStat(stats.kd) || !isUsableStat(stats.adr)) continue;
+    scores.push(scoreOpponent(stats));
+  }
+
+  if (scores.length === 0) {
+    return null;
+  }
+
+  const sum = scores.reduce((acc, value) => acc + value, 0);
+  const score = Math.round(sum / scores.length);
+
+  return {
+    score,
+    label: labelFor(score),
+    opponentCount: scores.length,
+  };
+}

--- a/test/integration/telemetry-discord-flow.integration.test.ts
+++ b/test/integration/telemetry-discord-flow.integration.test.ts
@@ -75,7 +75,20 @@ jest.mock('discord.js', () => ({
 
 // Mock the PUBG client
 jest.mock('@j03fr0st/pubg-ts', () => ({
-  ...jest.requireActual('@j03fr0st/pubg-ts'),
+  assetManager: {
+    getDamageCauserName: jest.fn(),
+    getGameModeName: jest.fn(),
+    getMapName: jest.fn(),
+  },
+  DAMAGE_CAUSER_NAME: {},
+  DamageInfoUtils: {
+    getFirst: jest.fn((damageInfo) => {
+      if (!damageInfo) return null;
+      return Array.isArray(damageInfo) ? (damageInfo[0] ?? null) : damageInfo;
+    }),
+  },
+  GAME_MODES: {},
+  MAP_NAMES: {},
   PubgClient: jest.fn().mockImplementation(() => ({
     telemetry: {
       getTelemetryData: jest.fn(),
@@ -667,6 +680,71 @@ describe('Telemetry Discord Flow Integration', () => {
         discordBotService.sendMatchSummary('test-channel-id', mockSummary)
       ).resolves.toBeUndefined();
       expect(mockChannel.send).toHaveBeenCalled();
+    });
+
+    it('includes opponent difficulty on the main summary when opponent season stats exist', async () => {
+      const mockSummary: DiscordMatchGroupSummary = {
+        matchId: 'test-match-difficulty',
+        mapName: 'Erangel',
+        gameMode: 'squad',
+        playedAt: '2024-01-01T10:00:00.000Z',
+        teamRank: 5,
+        telemetryUrl: 'https://telemetry-cdn.playbattlegrounds.com/test-match-difficulty',
+        players: [
+          {
+            name: 'TestPlayer1',
+            pubgId: 'tracked-1',
+            stats: createPlayerStats({
+              kills: 0,
+              DBNOs: 0,
+              damageDealt: 0,
+              timeSurvived: 1122,
+              winPlace: 5,
+              name: 'TestPlayer1',
+            }),
+          },
+        ],
+      };
+
+      const telemetry = [
+        {
+          _D: '2024-01-01T10:02:00.000Z',
+          _T: 'LogPlayerKillV2',
+          killer: { name: 'EnemyOne', accountId: 'enemy-1' },
+          victim: { name: 'TestPlayer1', accountId: 'tracked-1' },
+          damageCauserName: 'WeapBerylM762_C',
+        } as LogPlayerKillV2,
+      ];
+
+      const mockPubgClient = (discordBotService as any).pubgClient;
+      mockPubgClient.telemetry.getTelemetryData.mockResolvedValue(telemetry);
+
+      // Force the live telemetry path and avoid DB-backed lookups
+      (discordBotService as any).telemetryRepository = {
+        getCachedAnalyses: jest.fn().mockResolvedValue(null),
+        saveTelemetry: jest.fn().mockResolvedValue(undefined),
+      };
+      (discordBotService as any).matchRepository = {
+        findMatch: jest.fn().mockResolvedValue(null),
+      };
+      (discordBotService as any).playerStatsService = {
+        getSeasonStats: jest
+          .fn()
+          .mockResolvedValue(new Map([['enemy-1', { kd: 1.5, adr: 225 }]])),
+      };
+
+      const mockChannel = createMockTextChannel();
+      const mockClient = (discordBotService as any).client;
+      mockClient.channels.fetch.mockResolvedValue(mockChannel);
+
+      await discordBotService.sendMatchSummary('test-channel-id', mockSummary);
+
+      const firstCall = mockChannel.send.mock.calls[0][0];
+      const mainEmbed = firstCall.embeds[0].toJSON();
+
+      expect(mainEmbed.description).toContain(
+        'Opponent Difficulty: **Hard** (75/100, 1 opponent)'
+      );
     });
   });
 

--- a/test/unit/utils/match-difficulty.util.test.ts
+++ b/test/unit/utils/match-difficulty.util.test.ts
@@ -1,0 +1,331 @@
+import {
+  type OpponentDifficultyResult,
+  type OpponentSeasonStats,
+  calculateOpponentDifficulty,
+} from '../../../src/utils/match-difficulty.util';
+
+describe('calculateOpponentDifficulty', () => {
+  const stats = (kd: number, adr: number): OpponentSeasonStats => ({ kd, adr });
+
+  describe('baseline scoring', () => {
+    it('scores a 1.0 K/D, 150 ADR opponent as 50 Standard', () => {
+      const result = calculateOpponentDifficulty(
+        ['account.1'],
+        new Map([['account.1', stats(1.0, 150)]])
+      );
+      expect(result).toEqual<OpponentDifficultyResult>({
+        score: 50,
+        label: 'Standard',
+        opponentCount: 1,
+      });
+    });
+
+    it('scores a 0.5 K/D, 75 ADR opponent as 25 Easy', () => {
+      const result = calculateOpponentDifficulty(
+        ['account.1'],
+        new Map([['account.1', stats(0.5, 75)]])
+      );
+      expect(result).toEqual<OpponentDifficultyResult>({
+        score: 25,
+        label: 'Easy',
+        opponentCount: 1,
+      });
+    });
+
+    it('scores a 0 K/D, 0 ADR opponent as 0 Easy', () => {
+      const result = calculateOpponentDifficulty(
+        ['account.1'],
+        new Map([['account.1', stats(0, 0)]])
+      );
+      expect(result).toEqual<OpponentDifficultyResult>({
+        score: 0,
+        label: 'Easy',
+        opponentCount: 1,
+      });
+    });
+  });
+
+  describe('hard opponents', () => {
+    it('scores a 1.5 K/D, 225 ADR opponent as 75 Hard', () => {
+      const result = calculateOpponentDifficulty(
+        ['account.1'],
+        new Map([['account.1', stats(1.5, 225)]])
+      );
+      expect(result).toEqual<OpponentDifficultyResult>({
+        score: 75,
+        label: 'Hard',
+        opponentCount: 1,
+      });
+    });
+  });
+
+  describe('brutal opponents', () => {
+    it('scores a 2.0 K/D, 300 ADR opponent as 100 Brutal', () => {
+      const result = calculateOpponentDifficulty(
+        ['account.1'],
+        new Map([['account.1', stats(2.0, 300)]])
+      );
+      expect(result).toEqual<OpponentDifficultyResult>({
+        score: 100,
+        label: 'Brutal',
+        opponentCount: 1,
+      });
+    });
+
+    it('clamps extreme K/D and ADR to 100 Brutal', () => {
+      const result = calculateOpponentDifficulty(
+        ['account.1'],
+        new Map([['account.1', stats(10, 1500)]])
+      );
+      expect(result).toEqual<OpponentDifficultyResult>({
+        score: 100,
+        label: 'Brutal',
+        opponentCount: 1,
+      });
+    });
+  });
+
+  describe('label thresholds', () => {
+    it('labels a score of 34 as Easy', () => {
+      // 0.34 K/D + 51 ADR => ((0.34) + (0.34))/2 * 50 = 17 ; need score 34
+      // Use kd=0.68, adr=102 => ((0.68)+(0.68))/2*50 = 34
+      const result = calculateOpponentDifficulty(
+        ['account.1'],
+        new Map([['account.1', stats(0.68, 102)]])
+      );
+      expect(result?.label).toBe('Easy');
+      expect(result?.score).toBe(34);
+    });
+
+    it('labels a score of 35 as Standard', () => {
+      // kd=0.7, adr=105 => ((0.7)+(0.7))/2*50 = 35
+      const result = calculateOpponentDifficulty(
+        ['account.1'],
+        new Map([['account.1', stats(0.7, 105)]])
+      );
+      expect(result?.label).toBe('Standard');
+      expect(result?.score).toBe(35);
+    });
+
+    it('labels a score of 64 as Standard', () => {
+      // kd=1.28, adr=192 => ((1.28)+(1.28))/2*50 = 64
+      const result = calculateOpponentDifficulty(
+        ['account.1'],
+        new Map([['account.1', stats(1.28, 192)]])
+      );
+      expect(result?.label).toBe('Standard');
+      expect(result?.score).toBe(64);
+    });
+
+    it('labels a score of 65 as Hard', () => {
+      // kd=1.3, adr=195 => ((1.3)+(1.3))/2*50 = 65
+      const result = calculateOpponentDifficulty(
+        ['account.1'],
+        new Map([['account.1', stats(1.3, 195)]])
+      );
+      expect(result?.label).toBe('Hard');
+      expect(result?.score).toBe(65);
+    });
+
+    it('labels a score of 84 as Hard', () => {
+      // kd=1.68, adr=252 => ((1.68)+(1.68))/2*50 = 84
+      const result = calculateOpponentDifficulty(
+        ['account.1'],
+        new Map([['account.1', stats(1.68, 252)]])
+      );
+      expect(result?.label).toBe('Hard');
+      expect(result?.score).toBe(84);
+    });
+
+    it('labels a score of 85 as Brutal', () => {
+      // kd=1.7, adr=255 => ((1.7)+(1.7))/2*50 = 85
+      const result = calculateOpponentDifficulty(
+        ['account.1'],
+        new Map([['account.1', stats(1.7, 255)]])
+      );
+      expect(result?.label).toBe('Brutal');
+      expect(result?.score).toBe(85);
+    });
+  });
+
+  describe('multiple opponents', () => {
+    it('averages per-opponent scores with Math.round', () => {
+      // 1.0/150 => 50, 2.0/300 => 100, average 75 => Hard
+      const seasonStats = new Map<string, OpponentSeasonStats>([
+        ['account.1', stats(1.0, 150)],
+        ['account.2', stats(2.0, 300)],
+      ]);
+      const result = calculateOpponentDifficulty(['account.1', 'account.2'], seasonStats);
+      expect(result).toEqual<OpponentDifficultyResult>({
+        score: 75,
+        label: 'Hard',
+        opponentCount: 2,
+      });
+    });
+
+    it('rounds the averaged score to the nearest integer', () => {
+      // 50 and 75 average to 62.5 => rounds to 63 => Standard
+      const seasonStats = new Map<string, OpponentSeasonStats>([
+        ['account.1', stats(1.0, 150)],
+        ['account.2', stats(1.5, 225)],
+      ]);
+      const result = calculateOpponentDifficulty(['account.1', 'account.2'], seasonStats);
+      expect(result?.score).toBe(63);
+      expect(result?.label).toBe('Standard');
+      expect(result?.opponentCount).toBe(2);
+    });
+  });
+
+  describe('dedupe and validation', () => {
+    it('counts duplicate account IDs only once', () => {
+      const result = calculateOpponentDifficulty(
+        ['account.1', 'account.1', 'account.1'],
+        new Map([['account.1', stats(1.0, 150)]])
+      );
+      expect(result).toEqual<OpponentDifficultyResult>({
+        score: 50,
+        label: 'Standard',
+        opponentCount: 1,
+      });
+    });
+
+    it('ignores empty account IDs', () => {
+      const result = calculateOpponentDifficulty(
+        ['', 'account.1', ''],
+        new Map([
+          ['', stats(2.0, 300)],
+          ['account.1', stats(1.0, 150)],
+        ])
+      );
+      expect(result).toEqual<OpponentDifficultyResult>({
+        score: 50,
+        label: 'Standard',
+        opponentCount: 1,
+      });
+    });
+
+    it('ignores opponents missing from the season stats map', () => {
+      const result = calculateOpponentDifficulty(
+        ['account.1', 'account.missing'],
+        new Map([['account.1', stats(1.0, 150)]])
+      );
+      expect(result).toEqual<OpponentDifficultyResult>({
+        score: 50,
+        label: 'Standard',
+        opponentCount: 1,
+      });
+    });
+
+    it('ignores stats with negative K/D', () => {
+      const result = calculateOpponentDifficulty(
+        ['account.1', 'account.2'],
+        new Map([
+          ['account.1', stats(-1, 100)],
+          ['account.2', stats(1.0, 150)],
+        ])
+      );
+      expect(result?.score).toBe(50);
+      expect(result?.opponentCount).toBe(1);
+    });
+
+    it('ignores stats with negative ADR', () => {
+      const result = calculateOpponentDifficulty(
+        ['account.1', 'account.2'],
+        new Map([
+          ['account.1', stats(1.0, -10)],
+          ['account.2', stats(1.0, 150)],
+        ])
+      );
+      expect(result?.score).toBe(50);
+      expect(result?.opponentCount).toBe(1);
+    });
+
+    it('ignores stats with NaN K/D', () => {
+      const result = calculateOpponentDifficulty(
+        ['account.1', 'account.2'],
+        new Map([
+          ['account.1', stats(Number.NaN, 100)],
+          ['account.2', stats(1.0, 150)],
+        ])
+      );
+      expect(result?.score).toBe(50);
+      expect(result?.opponentCount).toBe(1);
+    });
+
+    it('ignores stats with NaN ADR', () => {
+      const result = calculateOpponentDifficulty(
+        ['account.1', 'account.2'],
+        new Map([
+          ['account.1', stats(1.0, Number.NaN)],
+          ['account.2', stats(1.0, 150)],
+        ])
+      );
+      expect(result?.score).toBe(50);
+      expect(result?.opponentCount).toBe(1);
+    });
+
+    it('ignores stats with Infinity K/D', () => {
+      const result = calculateOpponentDifficulty(
+        ['account.1', 'account.2'],
+        new Map([
+          ['account.1', stats(Number.POSITIVE_INFINITY, 100)],
+          ['account.2', stats(1.0, 150)],
+        ])
+      );
+      expect(result?.score).toBe(50);
+      expect(result?.opponentCount).toBe(1);
+    });
+
+    it('ignores stats with Infinity ADR', () => {
+      const result = calculateOpponentDifficulty(
+        ['account.1', 'account.2'],
+        new Map([
+          ['account.1', stats(1.0, Number.POSITIVE_INFINITY)],
+          ['account.2', stats(1.0, 150)],
+        ])
+      );
+      expect(result?.score).toBe(50);
+      expect(result?.opponentCount).toBe(1);
+    });
+  });
+
+  describe('no usable opponents', () => {
+    it('returns null when the input is empty', () => {
+      const result = calculateOpponentDifficulty([], new Map());
+      expect(result).toBeNull();
+    });
+
+    it('returns null when all opponents are missing from the map', () => {
+      const result = calculateOpponentDifficulty(['account.1'], new Map());
+      expect(result).toBeNull();
+    });
+
+    it('returns null when all stats are invalid', () => {
+      const seasonStats = new Map<string, OpponentSeasonStats>([
+        ['account.1', stats(-1, 100)],
+        ['account.2', stats(1.0, Number.NaN)],
+      ]);
+      const result = calculateOpponentDifficulty(['account.1', 'account.2'], seasonStats);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when only empty account IDs are provided', () => {
+      const result = calculateOpponentDifficulty(['', ''], new Map([['', stats(1.0, 150)]]));
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('iterable inputs', () => {
+    it('accepts a Set of account IDs', () => {
+      const result = calculateOpponentDifficulty(
+        new Set(['account.1']),
+        new Map([['account.1', stats(1.0, 150)]])
+      );
+      expect(result).toEqual<OpponentDifficultyResult>({
+        score: 50,
+        label: 'Standard',
+        opponentCount: 1,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds opponent difficulty scoring for Discord match summaries based on the encountered opponents' season K/D and ADR. The feature only renders when usable opponent season stats are available, so summaries without telemetry opponents or stats keep their existing shape.

## Changes
- Added a pure `calculateOpponentDifficulty` utility with validation, de-duplication, scoring, and labels.
- Integrated opponent collection and difficulty rendering into the Discord summary flow for live and cached telemetry paths.
- Added unit coverage for scoring boundaries and validation cases.
- Added integration coverage for the Discord summary difficulty line.

## Validation
- `npx jest test/integration/telemetry-discord-flow.integration.test.ts --runInBand`
- `npx jest test/unit/utils/match-difficulty.util.test.ts --runInBand`
- `npm run typecheck`

## Notes
- The integration test suite still emits its existing Jest one-second exit warning after passing.