### PR TITLE
fix(discord): exclude bot accounts from opponent season stats lookup

### DIFF
--- a/src/services/discord-bot.service.ts
+++ b/src/services/discord-bot.service.ts
@@ -1391,7 +1391,7 @@ export class DiscordBotService {
     const opponentAccountIds = new Set<string>();
 
     const addOpponent = (accountId?: string) => {
-      if (!accountId || trackedAccountIds.has(accountId)) return;
+      if (!accountId || trackedAccountIds.has(accountId) || isBotAccountId(accountId)) return;
       opponentAccountIds.add(accountId);
     };
 

--- a/src/services/player-stats.service.ts
+++ b/src/services/player-stats.service.ts
@@ -148,12 +148,22 @@ export class PlayerStatsService {
             continue;
           }
 
+          const roundsPlayed = modeStats.roundsPlayed ?? 0;
+          if (roundsPlayed === 0) {
+            // No games played in this exact mode this season - kd/adr would
+            // read as 0, which looks like a weak opponent rather than "no data".
+            debug('Season stats has no rounds played for account/gameMode', {
+              accountId,
+              gameMode,
+            });
+            continue;
+          }
+
           const kills = modeStats.kills ?? 0;
           const damageDealt = modeStats.damageDealt ?? 0;
           const deaths = modeStats.losses ?? 0;
           const kd = deaths > 0 ? kills / deaths : kills;
-          const roundsPlayed = modeStats.roundsPlayed ?? 0;
-          const adr = roundsPlayed > 0 ? damageDealt / roundsPlayed : 0;
+          const adr = damageDealt / roundsPlayed;
 
           const rounded = {
             kd: Math.round(kd * 100) / 100,

--- a/test/integration/telemetry-discord-flow.integration.test.ts
+++ b/test/integration/telemetry-discord-flow.integration.test.ts
@@ -747,6 +747,74 @@ describe('Telemetry Discord Flow Integration', () => {
       );
     });
 
+    it('excludes bot opponents from the season stats lookup', async () => {
+      const mockSummary: DiscordMatchGroupSummary = {
+        matchId: 'test-bot-opponent',
+        mapName: 'Erangel',
+        gameMode: 'squad',
+        playedAt: '2024-01-01T10:00:00.000Z',
+        teamRank: 5,
+        telemetryUrl: 'https://telemetry-cdn.playbattlegrounds.com/test-bot-opponent',
+        players: [
+          {
+            name: 'TestPlayer1',
+            pubgId: 'tracked-1',
+            stats: createPlayerStats({
+              kills: 1,
+              DBNOs: 0,
+              damageDealt: 100,
+              timeSurvived: 1122,
+              winPlace: 5,
+              name: 'TestPlayer1',
+            }),
+          },
+        ],
+      };
+
+      const telemetry = [
+        {
+          _D: '2024-01-01T10:01:00.000Z',
+          _T: 'LogPlayerKillV2',
+          killer: { name: 'TestPlayer1', accountId: 'tracked-1' },
+          victim: { name: 'BotEnemy', accountId: 'ai.1' },
+          damageCauserName: 'WeapBerylM762_C',
+        } as LogPlayerKillV2,
+        {
+          _D: '2024-01-01T10:02:00.000Z',
+          _T: 'LogPlayerKillV2',
+          killer: { name: 'EnemyOne', accountId: 'enemy-1' },
+          victim: { name: 'TestPlayer1', accountId: 'tracked-1' },
+          damageCauserName: 'WeapBerylM762_C',
+        } as LogPlayerKillV2,
+      ];
+
+      const mockPubgClient = (discordBotService as any).pubgClient;
+      mockPubgClient.telemetry.getTelemetryData.mockResolvedValue(telemetry);
+
+      (discordBotService as any).telemetryRepository = {
+        getCachedAnalyses: jest.fn().mockResolvedValue(null),
+        saveTelemetry: jest.fn().mockResolvedValue(undefined),
+      };
+      (discordBotService as any).matchRepository = {
+        findMatch: jest.fn().mockResolvedValue(null),
+      };
+      const getSeasonStats = jest
+        .fn()
+        .mockResolvedValue(new Map([['enemy-1', { kd: 1.5, adr: 225 }]]));
+      (discordBotService as any).playerStatsService = { getSeasonStats };
+
+      const mockChannel = createMockTextChannel();
+      const mockClient = (discordBotService as any).client;
+      mockClient.channels.fetch.mockResolvedValue(mockChannel);
+
+      await discordBotService.sendMatchSummary('test-channel-id', mockSummary);
+
+      expect(getSeasonStats).toHaveBeenCalled();
+      const requestedAccountIds = getSeasonStats.mock.calls[0][0];
+      expect(requestedAccountIds).not.toContain('ai.1');
+      expect(requestedAccountIds).toContain('enemy-1');
+    });
+
     it('includes lobby difficulty with bots on the main summary when participants are saved', async () => {
       const mockSummary: DiscordMatchGroupSummary = {
         matchId: 'test-lobby-difficulty',

--- a/test/unit/services/player-stats.service.test.ts
+++ b/test/unit/services/player-stats.service.test.ts
@@ -133,6 +133,27 @@ describe('PlayerStatsService', () => {
       });
     });
 
+    it('skips players with no rounds played in the requested game mode', async () => {
+      mockRepo.findByAccountIds.mockResolvedValue([]);
+
+      mockPubgClient.players.getPlayerSeasonStatsBatch.mockResolvedValue({
+        data: [
+          seasonStatsResponse('acc-1', {
+            kills: 0,
+            losses: 0,
+            roundsPlayed: 0,
+            damageDealt: 0,
+            wins: 0,
+          }),
+        ],
+      });
+
+      const results = await service.getSeasonStats(['acc-1'], 'squad-fpp');
+
+      expect(results.has('acc-1')).toBe(false);
+      expect(mockRepo.upsertStats).not.toHaveBeenCalled();
+    });
+
     it('skips players whose API call fails', async () => {
       mockRepo.findByAccountIds.mockResolvedValue([]);
 


### PR DESCRIPTION
collectOpponentAccountIds included AI bot account IDs (ai.*) alongside
real opponents when requesting season stats. PUBG's batch season-stats
endpoint rejects bot IDs, so any chunk of 10 accounts containing a bot
failed entirely and silently dropped season K/D/ADR for every human
opponent in that batch, leaving the enhanced timeline missing stats.