### PR TITLE
Add debug as direct dependency to fix runtime crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@j03fr0st/pubg-ts": "^2.0.0",
         "@prisma/adapter-pg": "^7.4.1",
         "@prisma/client": "^7.4.1",
+        "debug": "^4.4.3",
         "discord.js": "^14.16.3",
         "dotenv": "^16.4.5"
       },
@@ -3099,7 +3100,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5219,7 +5219,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mysql2": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@j03fr0st/pubg-ts": "^2.0.0",
     "@prisma/adapter-pg": "^7.4.1",
     "@prisma/client": "^7.4.1",
+    "debug": "^4.4.3",
     "discord.js": "^14.16.3",
     "dotenv": "^16.4.5"
   },


### PR DESCRIPTION
The app crashes at startup with "Cannot find module 'debug'" in
production. @j03fr0st/pubg-ts requires('debug') in its logger but
does not declare debug in its own dependencies. In dev this is
masked because devDependencies (jest/nodemon/ts-jest) pull debug in
transitively, but production installs (npm ci --only=production, as
in the Dockerfile) omit those, so debug is never installed.

Re-add debug as a direct dependency so it is present in production
installs, as anticipated by the repo-simplification task notes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011cw1ekVxxC3wrSLWuyYXrC